### PR TITLE
DEPRECATED:  snapshot.name_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
**DEPRECATED**: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info