### PR TITLE
Fix: Correctly validate numeric strings

### DIFF
--- a/write.go
+++ b/write.go
@@ -167,26 +167,28 @@ func getSheet(xlFile *xlsx.File, sheetNames []string, i int) (sheet *xlsx.Sheet,
 }
 
 func isNumeric(s string) bool {
-	var haveDot bool
-	for idx, c := range s {
-		if c == '.' {
-			if haveDot { // string with more than one dot
+	if s == "" {
+		return false
+	}
+
+	var haveDot, haveDigit bool
+	for i, c := range s {
+		switch {
+		case c == '.':
+			if haveDot {
 				return false
 			}
 			haveDot = true
-			continue
-		}
-		if c == '-' { // minus
-			if idx == 0 { // at the beginning
-				continue
-			} else {
+		case c == '-':
+			if i > 0 {
 				return false
 			}
-		}
-
-		if !unicode.IsDigit(c) {
+		case unicode.IsDigit(c):
+			haveDigit = true
+		default:
 			return false
 		}
 	}
-	return true
+
+	return haveDigit
 }

--- a/write_test.go
+++ b/write_test.go
@@ -44,4 +44,6 @@ func TestInNumeric(t *testing.T) {
 	assert.False(t, isNumeric("abc"))
 	assert.False(t, isNumeric("Inf"))
 	assert.False(t, isNumeric("1.."))
+	assert.False(t, isNumeric("."))
+	assert.False(t, isNumeric("-"))
 }


### PR DESCRIPTION
The isNumeric function was incorrectly identifying strings containing only a `.` or a `-` as numeric. This could lead to invalid data being written to the XLSX file.

This commit refactors the isNumeric function to correctly handle these edge cases. The new implementation ensures that a string must contain at least one digit to be considered numeric.

Additionally, new test cases have been added to `write_test.go` to cover these scenarios and prevent future regressions.